### PR TITLE
fix: install.sh — 14 fixes from CodeRabbit review

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,9 +47,11 @@ install_global() {
 
     # ─── Nuke-and-replace: remove stale files before copy — Fix #8, #9, #10 ───
     # This ensures deleted/renamed files don't persist from previous installs
+    # Guard: :? prevents accidental deletion if CLAUDE_DIR is somehow empty
+    : "${CLAUDE_DIR:?CLAUDE_DIR must be set}"
     for dir in agents commands rules scripts templates; do
         if [ -d "$CLAUDE_DIR/$dir" ]; then
-            rm -rf "$CLAUDE_DIR/$dir"
+            rm -rf "${CLAUDE_DIR:?}/$dir"
         fi
     done
 
@@ -127,7 +129,10 @@ install_global() {
 
     # ─── Install forge shell function — Fix #15, #17: check active source line + zsh ───
     echo "  Installing forge shell function..."
-    cp "$FORGE_DIR/scripts/forge-shell.sh" "$CLAUDE_DIR/forge-shell.sh"
+    if ! cp "$FORGE_DIR/scripts/forge-shell.sh" "$CLAUDE_DIR/forge-shell.sh"; then
+        echo -e "${RED}ERROR: Failed to copy forge-shell.sh — forge command will not work${NC}"
+        exit 1
+    fi
 
     local shell_installed=false
     for rc_file in "$HOME/.bashrc" "$HOME/.zshrc"; do
@@ -228,11 +233,12 @@ needs_update() {
     fi
 
     # Also check if any source file is newer than the newest installed file
+    # Use stat instead of find -printf for macOS/BSD compatibility
     local src_newest installed_newest
-    src_newest=$(find "$FORGE_DIR/agents" "$FORGE_DIR/commands" "$FORGE_DIR/scripts" -type f -printf '%T@\n' 2>/dev/null | sort -rn | head -1 || echo "0")
-    installed_newest=$(find "$CLAUDE_DIR/agents" "$CLAUDE_DIR/commands" "$CLAUDE_DIR/scripts" -type f -printf '%T@\n' 2>/dev/null | sort -rn | head -1 || echo "0")
+    src_newest=$(find "$FORGE_DIR/agents" "$FORGE_DIR/commands" "$FORGE_DIR/scripts" -type f -exec stat -c '%Y' {} \; 2>/dev/null | sort -rn | head -1 || find "$FORGE_DIR/agents" "$FORGE_DIR/commands" "$FORGE_DIR/scripts" -type f -exec stat -f '%m' {} \; 2>/dev/null | sort -rn | head -1 || echo "0")
+    installed_newest=$(find "$CLAUDE_DIR/agents" "$CLAUDE_DIR/commands" "$CLAUDE_DIR/scripts" -type f -exec stat -c '%Y' {} \; 2>/dev/null | sort -rn | head -1 || find "$CLAUDE_DIR/agents" "$CLAUDE_DIR/commands" "$CLAUDE_DIR/scripts" -type f -exec stat -f '%m' {} \; 2>/dev/null | sort -rn | head -1 || echo "0")
 
-    if [ "${src_newest%.*}" -gt "${installed_newest%.*}" ] 2>/dev/null; then
+    if [ "${src_newest}" -gt "${installed_newest}" ] 2>/dev/null; then
         echo -e "${YELLOW}Forge source files are newer than installed. Reinstalling...${NC}"
         return 0
     fi


### PR DESCRIPTION
## Summary

Fixes 14 of 22 issues identified by CodeRabbit in issue #39. Remaining 6 deferred to #46.

### Fixes Applied

| # | Category | Fix |
|---|----------|-----|
| 1 | Bug | Added `\|\| true` to universal agents cp (was crashing on empty dir) |
| 2 | Bug | Update detection compares ALL dirs, not just agents (was never triggering) |
| 4 | Bug | `readlink -f` for symlink-safe FORGE_DIR resolution |
| 5 | Edge case | Pre-flight validation checks forge source directory structure |
| 6 | Edge case | Warns when prep_project targets non-empty directory |
| 7 | Edge case | Checks python3 availability before validation |
| 8 | Stale files | **Nuke-and-replace** — rm -rf each target dir before copy |
| 9 | Stale files | Installed count now accurate (fixed by #8) |
| 10 | Stale files | Stack renames no longer accumulate (fixed by #8) |
| 11 | Error handling | Validation warnings shown, not swallowed |
| 12 | Error handling | Critical cp (forge-shell.sh) exits on failure |
| 14 | Security | chmod +x targets only `.sh` and `.py`, not all files |
| 15 | Security | .bashrc check uses regex for active (uncommented) source line |
| 17 | Missing | Also checks/installs to `.zshrc` for macOS/zsh users |
| 22 | Missing | File timestamp comparison + `--force` flag for update detection |

### Deferred to #46
- Git 2.28 requirement for `-b main`
- Integrity verification (checksums)
- `--uninstall` option
- `--dry-run` mode
- Backup before overwrite
- Atomic install rollback

### Test Results
```
$ bash install.sh
Installing Forge to ~/.claude
  Copying agents...
  Copying commands...
  Copying rules...
  Copying scripts...
  Copying templates...
  Validating...
  Validation passed
  Installing forge shell function...
  forge() already in ~/.bashrc

Forge installed:
  51 agents, 41 commands, 7 rules, 22 scripts, 20 templates
```

Closes #39

## Test plan
- [x] `install.sh` runs without errors
- [x] `install.sh --help` shows usage with --force
- [x] Counts match expected (51 agents, 41 commands, etc.)
- [x] Nuke-and-replace cleans old files
- [ ] CodeRabbit review and explicit approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--force` CLI flag to force reinstallation regardless of update status.

* **Bug Fixes**
  * Corrected symlink handling so installs resolve the correct directory.
  * Improved update detection to avoid false positives/negatives.

* **Improvements**
  * Pre-install checks now warn about missing prerequisites without failing.
  * Cleaner installs remove stale files before updating.
  * Shell config updates only add sourcing lines when not already present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->