### PR TITLE
feat: add bulk refactor threshold — escalate when >20 REQs suspect

### DIFF
--- a/scripts/forge-enforce.sh
+++ b/scripts/forge-enforce.sh
@@ -815,6 +815,7 @@ for req, entry in suspects.items():
     state.setdefault('suspect_history', []).append({'req': req, **entry})
 cleared = len(suspects)
 state['suspect_reqs'] = {}
+state.pop('bulk_refactor', None)
 with open('$SUSPECT_FILE', 'w') as f:
     json.dump(state, f, indent=2)
 print(f'[SUSPECT] Cleared {cleared} suspect REQ(s)')
@@ -822,13 +823,21 @@ print(f'[SUSPECT] Cleared {cleared} suspect REQ(s)')
         return 0
     fi
 
-    # Default: show suspect REQs
+    # Default: show suspect REQs + bulk refactor check (#53)
     python3 -c "
 import json
 with open('$SUSPECT_FILE') as f:
     state = json.load(f)
 suspects = state.get('suspect_reqs', {})
 unverified = {k: v for k, v in suspects.items() if not v.get('verified')}
+bulk = state.get('bulk_refactor', {})
+
+if bulk.get('requires_full_triangle'):
+    print(f'[SUSPECT] BULK REFACTOR — {bulk.get(\"suspect_count\", 0)} REQs suspect')
+    print(f'[SUSPECT] Full triangle check required before any gate proceeds')
+    print(f'[SUSPECT] Run: forge-triangle.sh check')
+    exit(1)
+
 if not unverified:
     print('[SUSPECT] No unverified suspect REQs')
     exit(0)

--- a/scripts/req-impact-check.py
+++ b/scripts/req-impact-check.py
@@ -244,10 +244,27 @@ def check_staged(update_state=False):
                 print(f"    {req} (depends on {info['cascaded_from']})")
             suspect_reqs.update(cascaded)
 
+    # Bulk refactor threshold (#53) — escalate when too many REQs become suspect
+    BULK_THRESHOLD = 20
+    if len(suspect_reqs) > BULK_THRESHOLD:
+        print("=" * 60)
+        print("BULK REFACTOR DETECTED")
+        print("=" * 60)
+        print(f"  {len(suspect_reqs)} REQs suspect (threshold: {BULK_THRESHOLD})")
+        print(f"  ACTION: Run forge-triangle.sh check before ANY gate proceeds")
+        print(f"  This commit will proceed, but gates will block until triangle passes.")
+
     # Update suspect state if requested
     if update_state and suspect_reqs:
         state = load_suspect_state()
         state["suspect_reqs"].update(suspect_reqs)
+        # Track bulk refactor flag
+        if len(suspect_reqs) > BULK_THRESHOLD:
+            state["bulk_refactor"] = {
+                "detected_at": datetime.now(timezone.utc).isoformat(),
+                "suspect_count": len(suspect_reqs),
+                "requires_full_triangle": True,
+            }
         save_suspect_state(state)
         print(f"  Updated {SUSPECT_FILE} with {len(suspect_reqs)} suspect REQ(s)")
 


### PR DESCRIPTION
## Summary

Escalation policy when a refactor makes too many REQs suspect at once.

- Threshold: >20 REQs suspect → BULK REFACTOR DETECTED
- `bulk_refactor` flag in suspect-reqs.json blocks all gates
- Cleared when `forge-triangle.sh check` passes (via --clear-all)

### Files Changed
- `scripts/req-impact-check.py` — threshold detection + bulk_refactor flag
- `scripts/forge-enforce.sh` — check-suspect reads bulk_refactor, --clear-all removes it

### Impact Check
Both files: no reverse deps, no flow participation affected.

### Traceability
- All existing functionality preserved
- Threshold is additive — only adds warning + flag
- No lines removed

Closes #53

## Test plan
- [x] `--impact` verified before changes
- [x] No functionality removed
- [ ] CodeRabbit review and explicit approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk refactor detection with automatic warnings. When suspect requirements exceed a defined threshold, the system displays a warning and prevents proceeding until a full triangle check is completed.

* **Bug Fixes**
  * Eliminated stale bulk refactor metadata by properly clearing it from the suspect requirement state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->