### PR TITLE
docs: make CodeRabbit required — gates block without CR approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,9 +363,9 @@ This is why templates use `{{PLACEHOLDERS}}` inside HTML comments — invisible 
 ## Requirements
 
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code)
-- Git + GitHub (`gh` CLI for issues and PRs)
+- Git + GitHub or GitLab (`gh` CLI for issues and PRs)
 - Python 3.10+ (for enforcement scripts)
-- Optional: CodeRabbit (for automated PR review)
+- Required: [CodeRabbit](https://coderabbit.ai) — used for PR review, architecture decisions, design review, issue review, edge case identification. Gates block without CR approval.
 - Optional: context7 MCP server (for library docs)
 
 ---

--- a/tests/bash/integration/coderabbit-required.bats
+++ b/tests/bash/integration/coderabbit-required.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+# Tests: CodeRabbit is required, not optional
+
+setup() {
+    load '../../test_helper/common-setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "README lists CodeRabbit as Required not Optional" {
+    run grep -i "required.*coderabbit\|coderabbit.*required" "$FORGE_DIR/README.md"
+    assert_success
+}
+
+@test "README does NOT say CodeRabbit is Optional" {
+    run grep -i "optional.*coderabbit" "$FORGE_DIR/README.md"
+    assert_failure
+}
+
+@test "gate command checks CodeRabbit approval" {
+    run grep -i "coderabbit\|CodeRabbit" "$FORGE_DIR/commands/gate.md"
+    assert_success
+}
+
+@test "SessionStart hook mentions CodeRabbit setup" {
+    run grep -i "coderabbit\|code.rabbit" "$FORGE_DIR/templates/hooks.json"
+    assert_success
+}


### PR DESCRIPTION
## Summary
CodeRabbit changed from Optional to Required in README.

Used for: PR review, architecture decisions, design review, issue review, edge case identification. Gates block without CR approval.

TDD: 4 tests → all pass.

Closes #96

- [ ] CodeRabbit explicit [approve]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated platform requirements to support Git with GitHub or GitLab
  * CodeRabbit is now required for code reviews, architecture/design reviews, issue analysis, and edge case identification
  * Review gates enforce CodeRabbit approval before proceeding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->