### PR TITLE
fix: Phase A Batch 2 — system-reminder, CLAUDE.md min lines, date literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ What gets installed (to `~/.claude/`, shared by all projects):
 | Rules | 7 | ~/.claude/rules/ | Global rules (security, python, docker, etc.) |
 | Scripts | 30 | ~/.claude/scripts/ | Enforcement, traceability, ownership, testing |
 | Templates | 22 | ~/.claude/templates/ | Project scaffolding (CLAUDE.md, SPEC.md, hooks, etc.) |
-| Tests | 336 | tests/ | BATS + pytest test suite (100% script coverage) |
+| Tests | 341 | tests/ | BATS + pytest test suite (100% script coverage) |
 | Shell fn | 1 | ~/.bashrc / ~/.zshrc | `forge` terminal command |
 
 ---

--- a/commands/forge-phases/phase-a-setup.md
+++ b/commands/forge-phases/phase-a-setup.md
@@ -4,7 +4,7 @@
 
 <system-reminder>
 SESSION 1 RULES:
-- PM orchestrates but NEVER writes CLAUDE.md, SPEC.md, or FORGE.md directly
+- PM orchestrates but NEVER writes CLAUDE.md or SPEC.md directly (FORGE.md is simple enough for PM)
 - Each file is built by a SPECIALIST AGENT following a TEMPLATE
 - Every agent output is VERIFIED before proceeding
 - Session 1 ends with "Setup complete. Run forge again to build."
@@ -177,7 +177,7 @@ Execute: spawn Agent with subagent_type="system-architect"
     - Tables for structured data
     - Anti-scope list from user's "NEVER include" answer
 
-Verify: `wc -l CLAUDE.md` → under 100 lines
+Verify: `wc -l CLAUDE.md` → at least 20 lines, under 100 lines (too short = missing rules)
 Verify: `grep -c "MUST\|NEVER" CLAUDE.md` → at least 5 binary rules
 Verify: has ## Tech Stack, ## Architecture Rules, ## What NOT to Build, ## Testing sections
 Trace: save to docs/forge-trace/S3-claude-md/
@@ -231,7 +231,7 @@ PM writes FORGE.md from template:
 - type: NEW_PROJECT
   description: {project description from discovery}
   status: QUEUED
-  created: {today's date}
+  created: $(date +%Y-%m-%d)
 
 ## Done
 <!-- Completed items -->

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -585,8 +585,8 @@ graph TD
     hooks_Stop --> scripts_forge_phase_gate_sh
     hooks_UserPromptSubmit --> scripts_forge_state_sync_sh
     hooks_PreToolUse_Edit --> scripts_forge_change_validator_sh
-    hooks_PostToolUse_Write|Edit --> scripts_forge_change_validator_sh
     hooks_PostToolUse_Write|Edit --> scripts_forge_auto_sync_sh
+    hooks_PostToolUse_Write|Edit --> scripts_forge_change_validator_sh
     hooks_PostToolUse_Agent --> scripts_forge_auto_state_sh
     hooks_PostToolUse_Skill --> scripts_forge_auto_state_sh
 ```

--- a/forge-registry.json
+++ b/forge-registry.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "generated": "2026-04-06T12:21:46.987372+00:00",
+  "generated": "2026-04-06T12:31:19.691395+00:00",
   "forge_dir": "/home/intruder/projects/forge",
   "stats": {
     "agents": 51,
@@ -2256,8 +2256,8 @@
         "matcher": "Write|Edit",
         "depends_on": {
           "scripts": [
-            "forge-change-validator.sh",
-            "forge-auto-sync.sh"
+            "forge-auto-sync.sh",
+            "forge-change-validator.sh"
           ]
         }
       },
@@ -4686,12 +4686,12 @@
     },
     {
       "from": "hooks/PostToolUse:Write|Edit",
-      "to": "scripts/forge-change-validator.sh",
+      "to": "scripts/forge-auto-sync.sh",
       "type": "scripts"
     },
     {
       "from": "hooks/PostToolUse:Write|Edit",
-      "to": "scripts/forge-auto-sync.sh",
+      "to": "scripts/forge-change-validator.sh",
       "type": "scripts"
     },
     {
@@ -6655,6 +6655,110 @@
     }
   },
   "changelog": {
+    "commands": [
+      {
+        "date": "2026-04-06",
+        "commit": "0a69d0ef",
+        "change_type": "bugfix",
+        "scope": "commands",
+        "summary": "Phase A Batch 1 \u2014 S2 question fixes #135 #138 #146",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "README.md",
+          "commands/forge-phases/phase-a-setup.md",
+          "docs/dependency-graph.md",
+          "forge-registry.json",
+          "tests/bash/unit/phase-a-fixes.bats"
+        ],
+        "issues": [
+          "#135",
+          "#138",
+          "#146",
+          "#147",
+          "#135",
+          "#147",
+          "#138",
+          "#146"
+        ]
+      },
+      {
+        "date": "2026-04-06",
+        "commit": "2c6f13c7",
+        "change_type": "bugfix",
+        "scope": "commands",
+        "summary": "Phase A S1 \u2014 add git init guard if .git missing",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "README.md",
+          "commands/forge-phases/phase-a-setup.md",
+          "forge-registry.json",
+          "tests/bash/unit/phase-a-fixes.bats"
+        ],
+        "issues": [
+          "#129",
+          "#130",
+          "#134",
+          "#155"
+        ]
+      },
+      {
+        "date": "2026-04-06",
+        "commit": "9fc956a4",
+        "change_type": "test",
+        "scope": "commands",
+        "summary": "add 6 validation tests for 45 commands",
+        "breaking": false,
+        "requires_reinstall": false,
+        "files": [
+          "tests/bash/unit/all-commands-validation.bats"
+        ],
+        "issues": [
+          "#83"
+        ]
+      },
+      {
+        "date": "2026-04-05",
+        "commit": "90a0c99f",
+        "change_type": "feature",
+        "scope": "commands",
+        "summary": "add 9 sc:* commands from SuperClaude \u2014 unblocks Phase 2, 4, 5",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "commands/sc-analyze.md",
+          "commands/sc-cleanup.md",
+          "commands/sc-document.md",
+          "commands/sc-estimate.md",
+          "commands/sc-improve.md",
+          "commands/sc-reflect.md",
+          "commands/sc-save.md",
+          "commands/sc-test.md",
+          "commands/sc-workflow.md",
+          "tests/bash/unit/sc-commands.bats"
+        ],
+        "issues": [
+          "#61"
+        ]
+      },
+      {
+        "date": "2026-04-05",
+        "commit": "ac88ee95",
+        "change_type": "feature",
+        "scope": "commands",
+        "summary": "create /autoresearch command \u2014 unblocks Phase 5 step 54",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "commands/autoresearch.md",
+          "tests/bash/unit/autoresearch-command.bats"
+        ],
+        "issues": [
+          "#60"
+        ]
+      }
+    ],
     "docs": [
       {
         "date": "2026-04-06",
@@ -6746,84 +6850,6 @@
         ],
         "issues": [
           "#48"
-        ]
-      }
-    ],
-    "commands": [
-      {
-        "date": "2026-04-06",
-        "commit": "2c6f13c7",
-        "change_type": "bugfix",
-        "scope": "commands",
-        "summary": "Phase A S1 \u2014 add git init guard if .git missing",
-        "breaking": false,
-        "requires_reinstall": true,
-        "files": [
-          "README.md",
-          "commands/forge-phases/phase-a-setup.md",
-          "forge-registry.json",
-          "tests/bash/unit/phase-a-fixes.bats"
-        ],
-        "issues": [
-          "#129",
-          "#130",
-          "#134",
-          "#155"
-        ]
-      },
-      {
-        "date": "2026-04-06",
-        "commit": "9fc956a4",
-        "change_type": "test",
-        "scope": "commands",
-        "summary": "add 6 validation tests for 45 commands",
-        "breaking": false,
-        "requires_reinstall": false,
-        "files": [
-          "tests/bash/unit/all-commands-validation.bats"
-        ],
-        "issues": [
-          "#83"
-        ]
-      },
-      {
-        "date": "2026-04-05",
-        "commit": "90a0c99f",
-        "change_type": "feature",
-        "scope": "commands",
-        "summary": "add 9 sc:* commands from SuperClaude \u2014 unblocks Phase 2, 4, 5",
-        "breaking": false,
-        "requires_reinstall": true,
-        "files": [
-          "commands/sc-analyze.md",
-          "commands/sc-cleanup.md",
-          "commands/sc-document.md",
-          "commands/sc-estimate.md",
-          "commands/sc-improve.md",
-          "commands/sc-reflect.md",
-          "commands/sc-save.md",
-          "commands/sc-test.md",
-          "commands/sc-workflow.md",
-          "tests/bash/unit/sc-commands.bats"
-        ],
-        "issues": [
-          "#61"
-        ]
-      },
-      {
-        "date": "2026-04-05",
-        "commit": "ac88ee95",
-        "change_type": "feature",
-        "scope": "commands",
-        "summary": "create /autoresearch command \u2014 unblocks Phase 5 step 54",
-        "breaking": false,
-        "requires_reinstall": true,
-        "files": [
-          "commands/autoresearch.md",
-          "tests/bash/unit/autoresearch-command.bats"
-        ],
-        "issues": [
-          "#60"
         ]
       }
     ],

--- a/tests/bash/unit/phase-a-fixes.bats
+++ b/tests/bash/unit/phase-a-fixes.bats
@@ -50,3 +50,37 @@ teardown() {
     run grep -iE "no competitor|nothing found|skip competitor|no result" "$PHASE_A"
     assert_success
 }
+
+# ─── Batch 2: S3-S5 Generation Fixes ───
+
+# #131: System-reminder allows PM to write FORGE.md
+@test "Phase A system-reminder does NOT forbid FORGE.md" {
+    # Should say "NEVER writes CLAUDE.md or SPEC.md" not "FORGE.md"
+    run grep "NEVER writes CLAUDE.md, SPEC.md, or FORGE.md" "$PHASE_A"
+    assert_failure  # This old text should NOT exist
+}
+
+# #133: Stack learnings injected into agent prompts
+@test "Phase A S3 prompt includes stack learnings" {
+    run grep -iE "STACK_LEARNINGS|stack.*learnings|learnings.*apply|past.*build.*lessons" "$PHASE_A"
+    assert_success
+}
+
+# #139: Stack rules flexible not Django-only
+@test "Phase A S3 has rules for multiple stacks not just Django" {
+    run grep -iE "For FastAPI|For Next|For Go|For any|stack-specific|based on stack" "$PHASE_A"
+    assert_success
+}
+
+# #140: CLAUDE.md has minimum line count
+@test "Phase A S3 verifies CLAUDE.md has minimum content" {
+    run grep -iE "at least.*lines|minimum.*lines|min.*line|too short" "$PHASE_A"
+    assert_success
+}
+
+# #143: S5 uses real date not literal
+@test "Phase A S5 uses date command not literal {today}" {
+    # Should NOT have literal {today's date}
+    run grep "{today's date}" "$PHASE_A"
+    assert_failure  # This literal should NOT exist
+}


### PR DESCRIPTION
## Summary
Phase A S3-S5 generation fixes:
- #131: PM can write FORGE.md (removed from NEVER list)
- #140: CLAUDE.md minimum 20 lines (was max 100 only)
- #143: Real date command not literal
- #133, #139: already present, verified

TDD: 5 tests. 319 total, 0 failures.

Closes #131, Closes #133, Closes #139, Closes #140, Closes #143

- [ ] CodeRabbit explicit APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test suite count to 341 tests in README
  * Revised Phase A system documentation with updated guidelines
  * Updated dependency graph visualization

* **Tests**
  * Added 5 new Phase A behavior validation tests

* **Chores**
  * Updated system registry and changelog entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->