### PR TITLE
fix: simplify Phase A S1 — remove duplicate hook detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ What gets installed (to `~/.claude/`, shared by all projects):
 | Rules | 7 | ~/.claude/rules/ | Global rules (security, python, docker, etc.) |
 | Scripts | 30 | ~/.claude/scripts/ | Enforcement, traceability, ownership, testing |
 | Templates | 22 | ~/.claude/templates/ | Project scaffolding (CLAUDE.md, SPEC.md, hooks, etc.) |
-| Tests | 349 | tests/ | BATS + pytest test suite (100% script coverage) |
+| Tests | 351 | tests/ | BATS + pytest test suite (100% script coverage) |
 | Shell fn | 1 | ~/.bashrc / ~/.zshrc | `forge` terminal command |
 
 ---

--- a/commands/forge-phases/phase-a-setup.md
+++ b/commands/forge-phases/phase-a-setup.md
@@ -11,34 +11,29 @@ SESSION 1 RULES:
 - NO CODE IS WRITTEN in Session 1 — only planning/spec/config files
 </system-reminder>
 
-**STEP S1: ASSESS** (PM scans folder — no agents)
+**STEP S1: PREPARE** (PM prepares workspace — no agents)
+
+NOTE: Project type detection (GREENFIELD/BROWNFIELD/EXISTING) was already done by the UserPromptSubmit hook before reaching this file. S1 does NOT re-detect — it only prepares the workspace.
 
 ```bash
-# PM runs these checks automatically
-
-# Guard: ensure git repo exists (user may have forgotten git init)
+# 1. Ensure git repo (user may have forgotten git init)
 if [ ! -d ".git" ]; then
     git init -b main
     echo "[FORGE] Initialized git repository"
 fi
 
-# Guard: ensure docs/forge-trace exists (S3-S7 write traces here)
-mkdir -p docs/forge-trace
+# 2. Create directories needed by S3-S9
+mkdir -p docs/forge-trace docs/proposals docs/retrospectives
 
-ls CLAUDE.md 2>/dev/null          # exists?
-ls SPEC.md 2>/dev/null            # exists?
-ls FORGE.md 2>/dev/null           # exists?
-ls .forge/ 2>/dev/null            # forge initialized?
-ls .claude/ 2>/dev/null           # claude rules exist?
-find . -maxdepth 4 \( -name "*.py" -o -name "*.ts" -o -name "*.tsx" -o -name "*.jsx" -o -name "*.js" -o -name "*.go" -o -name "*.rb" -o -name "*.java" -o -name "*.rs" -o -name "*.php" \) ! -path "*node_modules*" ! -path "*.venv*" ! -path "*.git*" ! -path "*/vendor/*" 2>/dev/null | head -1  # code exists?
-cat CLAUDE.md 2>/dev/null | grep -E "FORGE_TEMPLATE|{{PROJECT_NAME}}|{{DESCRIPTION}}" | head -1  # forge placeholder?
+# 3. Check for partial setup (Phase A was interrupted previously)
+# If CLAUDE.md exists but SPEC.md or .forge/ is missing → resume from missing step
 ```
 
-Based on scan:
-- EMPTY folder → continue to STEP S2 (full setup)
-- Code exists, no CLAUDE.md → jump to STEP S5-BROWNFIELD
-- CLAUDE.md with placeholders → continue to STEP S2
-- Incomplete setup (CLAUDE.md but missing SPEC.md or scaffold or .forge/) → resume from missing step
+Based on partial setup check:
+- Nothing exists → continue to STEP S2 (full setup)
+- CLAUDE.md exists but no SPEC.md → resume at S4
+- CLAUDE.md + SPEC.md but no scaffold → resume at S7
+- Incomplete setup (CLAUDE.md but missing .forge/) → resume from missing step
 - Everything exists → "Setup already complete. Run /forge again to build."
 
 **STEP S2: DISCOVERY CONVERSATION** (PM only — gathers information)

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -585,8 +585,8 @@ graph TD
     hooks_Stop --> scripts_forge_phase_gate_sh
     hooks_UserPromptSubmit --> scripts_forge_state_sync_sh
     hooks_PreToolUse_Edit --> scripts_forge_change_validator_sh
-    hooks_PostToolUse_Write|Edit --> scripts_forge_auto_sync_sh
     hooks_PostToolUse_Write|Edit --> scripts_forge_change_validator_sh
+    hooks_PostToolUse_Write|Edit --> scripts_forge_auto_sync_sh
     hooks_PostToolUse_Agent --> scripts_forge_auto_state_sh
     hooks_PostToolUse_Skill --> scripts_forge_auto_state_sh
 ```

--- a/forge-registry.json
+++ b/forge-registry.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "generated": "2026-04-06T12:51:25.171411+00:00",
+  "generated": "2026-04-06T13:19:14.761636+00:00",
   "forge_dir": "/home/intruder/projects/forge",
   "stats": {
     "agents": 51,
@@ -2256,8 +2256,8 @@
         "matcher": "Write|Edit",
         "depends_on": {
           "scripts": [
-            "forge-auto-sync.sh",
-            "forge-change-validator.sh"
+            "forge-change-validator.sh",
+            "forge-auto-sync.sh"
           ]
         }
       },
@@ -4686,12 +4686,12 @@
     },
     {
       "from": "hooks/PostToolUse:Write|Edit",
-      "to": "scripts/forge-auto-sync.sh",
+      "to": "scripts/forge-change-validator.sh",
       "type": "scripts"
     },
     {
       "from": "hooks/PostToolUse:Write|Edit",
-      "to": "scripts/forge-change-validator.sh",
+      "to": "scripts/forge-auto-sync.sh",
       "type": "scripts"
     },
     {
@@ -6656,6 +6656,25 @@
   },
   "changelog": {
     "commands": [
+      {
+        "date": "2026-04-06",
+        "commit": "b3be62b4",
+        "change_type": "bugfix",
+        "scope": "commands",
+        "summary": "brownfield \u2014 multi-framework detection + missing infra check #149",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "commands/forge-phases/phase-a-setup.md",
+          "forge-registry.json"
+        ],
+        "issues": [
+          "#149",
+          "#152",
+          "#149",
+          "#152"
+        ]
+      },
       {
         "date": "2026-04-06",
         "commit": "ecdde2e4",

--- a/tests/bash/unit/phase-a-fixes.bats
+++ b/tests/bash/unit/phase-a-fixes.bats
@@ -16,12 +16,18 @@ teardown() {
 
 # ─── #129: git init guard in S1 ───
 
-@test "Phase A S1 has git init if .git missing" {
-    # S1 ASSESS should check for .git and init if missing
-    run grep -A3 "STEP S1" "$PHASE_A"
-    assert_success
-    # The S1 section should contain git init guard
+@test "Phase A S1 has git init guard" {
     run grep "git init" "$PHASE_A"
+    assert_success
+}
+
+@test "Phase A S1 does NOT re-detect project type" {
+    run grep -iE "already done|NOT re-detect|hook.*before|UserPromptSubmit" "$PHASE_A"
+    assert_success
+}
+
+@test "Phase A S1 creates directories for S3-S9" {
+    run grep "mkdir.*docs/forge-trace" "$PHASE_A"
     assert_success
 }
 


### PR DESCRIPTION
## Summary

S1 was repeating checks the UserPromptSubmit hook already did. Simplified to only:
1. git init if missing
2. mkdir dirs for S3-S9
3. Partial setup detection (resume from missing step)

Removed all duplicate detection (CLAUDE.md, code files, project type).
Added NOTE explaining hook already handled this.

TDD: 3 tests. 329 total, 0 failures.

Closes #169

- [ ] CodeRabbit explicit APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * STEP S1 renamed to "PREPARE" with a simplified setup detection workflow.
  * Updated directory structure to create `docs/proposals` and `docs/retrospectives` directories.

* **Bug Fixes**
  * Fixed brownfield multi-framework detection and missing infrastructure checks (requires reinstall).

* **Tests**
  * Expanded Phase A test coverage to validate initialization and configuration detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->