### PR TITLE
feat: extract PM behaviors into auto-loaded rules — who vs what separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ What gets installed (to `~/.claude/`, shared by all projects):
 |-----------|-------|----------|---------|
 | Agents | 53 | ~/.claude/agents/ | Specialist AI agents (backend, security, reviewer, etc.) |
 | Commands | 45 | ~/.claude/commands/ | Slash commands (/forge, /discover, /gate, sc:*, etc.) |
-| Rules | 7 | ~/.claude/rules/ | Global rules (security, python, docker, etc.) |
+| Rules | 8 | ~/.claude/rules/ | Global rules (security, python, docker, PM behaviors, etc.) |
 | Scripts | 30 | ~/.claude/scripts/ | Enforcement, traceability, ownership, testing |
 | Templates | 22 | ~/.claude/templates/ | Project scaffolding (CLAUDE.md, SPEC.md, hooks, etc.) |
-| Tests | 351 | tests/ | BATS + pytest test suite (100% script coverage) |
+| Tests | 368 | tests/ | BATS + pytest test suite (100% script coverage) |
 | Shell fn | 1 | ~/.bashrc / ~/.zshrc | `forge` terminal command |
 
 ---

--- a/agents/universal/pm-orchestrator.md
+++ b/agents/universal/pm-orchestrator.md
@@ -11,6 +11,8 @@ mcp-servers: [sequential, context7, playwright, serena]
 
 > You are the brain of Forge. You NEVER write application code. You orchestrate, delegate, review, learn, and enforce. Every user request flows through you. Every agent output is evaluated by you. Every lesson is captured by you.
 
+> **Architecture note:** Core PM behaviors (self-correction, anti-patterns, confidence routing, handoff protocol, chaos resilience) are auto-loaded from `rules/pm-behaviors.md` via Pipe 1. This file contains routing tables and detailed reference material. Phase files (phase-a-setup.md etc.) contain task steps ("what"). Rules contain behaviors ("who/how").
+
 ## What You Know
 
 <system-reminder>

--- a/commands/forge-phases/phase-a-setup.md
+++ b/commands/forge-phases/phase-a-setup.md
@@ -2,11 +2,16 @@
 
 #### Phase A — Setup (Session 1: creates all files agents need)
 
+<!-- Architecture: PM behaviors (self-correction, anti-patterns, confidence routing,
+     chaos resilience) are auto-loaded from rules/pm-behaviors.md via Pipe 1.
+     This file contains only the TASK STEPS (what to do), not PM behaviors (how to behave). -->
+
 <system-reminder>
 SESSION 1 RULES:
+- PM behaviors auto-loaded from rules/pm-behaviors.md (self-correction, anti-patterns, handoff protocol)
 - PM orchestrates but NEVER writes CLAUDE.md or SPEC.md directly (FORGE.md is simple enough for PM)
 - Each file is built by a SPECIALIST AGENT following a TEMPLATE
-- Every agent output is VERIFIED before proceeding
+- Every agent output is VERIFIED before proceeding (rate >= 4, retry if < 4, max 3)
 - Session 1 ends with "Setup complete. Run forge again to build."
 - NO CODE IS WRITTEN in Session 1 — only planning/spec/config files
 </system-reminder>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,9 +74,19 @@ copies to ~/.claude/:              checks if forge installed
 ├── agents/           ← agent definitions (loaded by Agent tool)
 ├── commands/         ← skill definitions (loaded as /slash commands)
 │   └── forge-phases/ ← phase execution files (read by /forge)
-├── rules/            ← global rules (auto-loaded in all projects)
+├── rules/            ← global rules (auto-loaded in all projects via Pipe 1)
+│   ├── pm-behaviors.md    ← PM orchestrator behaviors (self-correction, anti-patterns, handoff)
+│   ├── forge-enforcement.md ← hard rules for forge flow
+│   ├── security.md        ← security rules
+│   ├── universal.md       ← universal rules with governance levels
+│   ├── python.md, django.md, docker.md, forge-philosophy.md
 ├── scripts/          ← automation scripts (called by hooks)
 └── templates/        ← project templates (read by Phase A)
+
+Architecture separation (who vs what):
+  rules/pm-behaviors.md           → WHO: PM behaviors (auto-loaded, ~100 lines)
+  agents/universal/pm-orchestrator.md → REFERENCE: routing tables, detailed patterns
+  commands/forge-phases/*.md      → WHAT: task steps for each phase
 
 ~/projects/my-app/                 (PROJECT — created by /forge Phase A)
 ├── CLAUDE.md         ← project instructions (auto-loaded, Pipe 1)

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -515,6 +515,7 @@ graph TD
     commands_phase_phase_a_setup --> commands_requirements
     commands_phase_phase_a_setup --> commands_retro
     commands_phase_phase_a_setup --> scripts_forge_enforce_sh
+    commands_phase_phase_a_setup --> scripts_forge_infra_check_sh
     commands_phase_phase_a_setup --> scripts_forge_stack_sh
     commands_phase_phase_3_implement --> agents_backend_architect
     commands_phase_phase_3_implement --> agents_context_loader_agent

--- a/forge-registry.json
+++ b/forge-registry.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "generated": "2026-04-06T13:48:43.164086+00:00",
+  "generated": "2026-04-06T20:58:52.219626+00:00",
   "forge_dir": "/home/intruder/projects/forge",
   "stats": {
     "agents": 51,
@@ -8,7 +8,7 @@
     "scripts": 30,
     "hooks": 9,
     "templates": 17,
-    "rules": 7,
+    "rules": 8,
     "edges": 458,
     "phase_mapped_components": 50,
     "flows": 9
@@ -2395,6 +2395,11 @@
       "forge-philosophy.md": {
         "type": "rule",
         "path": "rules/forge-philosophy.md",
+        "depends_on": {}
+      },
+      "pm-behaviors.md": {
+        "type": "rule",
+        "path": "rules/pm-behaviors.md",
         "depends_on": {}
       },
       "docker.md": {
@@ -6682,7 +6687,297 @@
     }
   },
   "changelog": {
+    "commands": [
+      {
+        "date": "2026-04-06",
+        "commit": "6f9c1ff7",
+        "change_type": "test",
+        "scope": "commands",
+        "summary": "add tsconfig + apps/__init__ scaffold tests per CR",
+        "breaking": false,
+        "requires_reinstall": false,
+        "files": [
+          "tests/bash/unit/phase-a-fixes.bats"
+        ]
+      },
+      {
+        "date": "2026-04-06",
+        "commit": "07de44b3",
+        "change_type": "bugfix",
+        "scope": "commands",
+        "summary": "add tsconfig.json to Next.js scaffold list",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "commands/forge-phases/phase-a-setup.md"
+        ]
+      },
+      {
+        "date": "2026-04-06",
+        "commit": "c0833eae",
+        "change_type": "bugfix",
+        "scope": "commands",
+        "summary": "add conftest.py to scaffold + split tests + missing tests from PR",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "commands/forge-phases/phase-a-setup.md",
+          "tests/bash/unit/phase-a-fixes.bats"
+        ],
+        "issues": [
+          "#144",
+          "#153",
+          "#154",
+          "#167"
+        ]
+      },
+      {
+        "date": "2026-04-06",
+        "commit": "9bca6a72",
+        "change_type": "bugfix",
+        "scope": "commands",
+        "summary": "address remaining CR comments \u2014 scaffold test, registry regenerate",
+        "breaking": false,
+        "requires_reinstall": false,
+        "files": [
+          "forge-registry.json"
+        ],
+        "issues": [
+          "#154"
+        ]
+      },
+      {
+        "date": "2026-04-06",
+        "commit": "cf85b472",
+        "change_type": "bugfix",
+        "scope": "commands",
+        "summary": "address CR changes \u2014 recovery path, multi-stack downstream, full script path",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "commands/forge-phases/phase-a-setup.md"
+        ],
+        "issues": [
+          "#154",
+          "#167"
+        ]
+      },
+      {
+        "date": "2026-04-06",
+        "commit": "8993babe",
+        "change_type": "bugfix",
+        "scope": "commands",
+        "summary": "simplify Phase A S1 \u2014 remove duplicate detection, keep only prepare",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "README.md",
+          "commands/forge-phases/phase-a-setup.md",
+          "docs/dependency-graph.md",
+          "forge-registry.json",
+          "tests/bash/unit/phase-a-fixes.bats"
+        ],
+        "issues": [
+          "#169"
+        ]
+      },
+      {
+        "date": "2026-04-06",
+        "commit": "b3be62b4",
+        "change_type": "bugfix",
+        "scope": "commands",
+        "summary": "brownfield \u2014 multi-framework detection + missing infra check #149",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "commands/forge-phases/phase-a-setup.md",
+          "forge-registry.json"
+        ],
+        "issues": [
+          "#149",
+          "#152"
+        ]
+      },
+      {
+        "date": "2026-04-06",
+        "commit": "ecdde2e4",
+        "change_type": "bugfix",
+        "scope": "commands",
+        "summary": "Phase A Batch 4 \u2014 state persistence + partial setup + S9 fix path #132 #156",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "README.md",
+          "commands/forge-phases/phase-a-setup.md",
+          "docs/dependency-graph.md",
+          "forge-registry.json",
+          "tests/bash/unit/phase-a-fixes.bats"
+        ],
+        "issues": [
+          "#132",
+          "#156",
+          "#159"
+        ]
+      },
+      {
+        "date": "2026-04-06",
+        "commit": "bf71e57a",
+        "change_type": "bugfix",
+        "scope": "commands",
+        "summary": "Phase A Batch 3 \u2014 S6-S8 infrastructure fixes #136 #137 #145 #157",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "README.md",
+          "commands/forge-phases/phase-a-setup.md",
+          "docs/dependency-graph.md",
+          "forge-registry.json",
+          "tests/bash/unit/phase-a-fixes.bats"
+        ],
+        "issues": [
+          "#136",
+          "#137",
+          "#145",
+          "#157",
+          "#158"
+        ]
+      },
+      {
+        "date": "2026-04-06",
+        "commit": "aa742c1a",
+        "change_type": "bugfix",
+        "scope": "commands",
+        "summary": "Phase A Batch 2 \u2014 S3-S5 generation fixes #131 #133 #139 #140",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "README.md",
+          "commands/forge-phases/phase-a-setup.md",
+          "docs/dependency-graph.md",
+          "forge-registry.json",
+          "tests/bash/unit/phase-a-fixes.bats"
+        ],
+        "issues": [
+          "#131",
+          "#133",
+          "#139",
+          "#140",
+          "#143"
+        ]
+      },
+      {
+        "date": "2026-04-06",
+        "commit": "0a69d0ef",
+        "change_type": "bugfix",
+        "scope": "commands",
+        "summary": "Phase A Batch 1 \u2014 S2 question fixes #135 #138 #146",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "README.md",
+          "commands/forge-phases/phase-a-setup.md",
+          "docs/dependency-graph.md",
+          "forge-registry.json",
+          "tests/bash/unit/phase-a-fixes.bats"
+        ],
+        "issues": [
+          "#135",
+          "#138",
+          "#146",
+          "#147"
+        ]
+      },
+      {
+        "date": "2026-04-06",
+        "commit": "2c6f13c7",
+        "change_type": "bugfix",
+        "scope": "commands",
+        "summary": "Phase A S1 \u2014 add git init guard if .git missing",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "README.md",
+          "commands/forge-phases/phase-a-setup.md",
+          "forge-registry.json",
+          "tests/bash/unit/phase-a-fixes.bats"
+        ],
+        "issues": [
+          "#129",
+          "#130",
+          "#134",
+          "#155"
+        ]
+      },
+      {
+        "date": "2026-04-06",
+        "commit": "9fc956a4",
+        "change_type": "test",
+        "scope": "commands",
+        "summary": "add 6 validation tests for 45 commands",
+        "breaking": false,
+        "requires_reinstall": false,
+        "files": [
+          "tests/bash/unit/all-commands-validation.bats"
+        ],
+        "issues": [
+          "#83"
+        ]
+      },
+      {
+        "date": "2026-04-05",
+        "commit": "90a0c99f",
+        "change_type": "feature",
+        "scope": "commands",
+        "summary": "add 9 sc:* commands from SuperClaude \u2014 unblocks Phase 2, 4, 5",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "commands/sc-analyze.md",
+          "commands/sc-cleanup.md",
+          "commands/sc-document.md",
+          "commands/sc-estimate.md",
+          "commands/sc-improve.md",
+          "commands/sc-reflect.md",
+          "commands/sc-save.md",
+          "commands/sc-test.md",
+          "commands/sc-workflow.md",
+          "tests/bash/unit/sc-commands.bats"
+        ],
+        "issues": [
+          "#61"
+        ]
+      },
+      {
+        "date": "2026-04-05",
+        "commit": "ac88ee95",
+        "change_type": "feature",
+        "scope": "commands",
+        "summary": "create /autoresearch command \u2014 unblocks Phase 5 step 54",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "commands/autoresearch.md",
+          "tests/bash/unit/autoresearch-command.bats"
+        ],
+        "issues": [
+          "#60"
+        ]
+      }
+    ],
     "scripts": [
+      {
+        "date": "2026-04-06",
+        "commit": "98c5b1fe",
+        "change_type": "bugfix",
+        "scope": "scripts",
+        "summary": "natural sort for phase_index \u2014 S2 before S10",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "forge-registry.json",
+          "scripts/forge-registry.py"
+        ]
+      },
       {
         "date": "2026-04-06",
         "commit": "485442df",
@@ -7303,259 +7598,6 @@
           "#35",
           "#36",
           "#37"
-        ]
-      }
-    ],
-    "commands": [
-      {
-        "date": "2026-04-06",
-        "commit": "c0833eae",
-        "change_type": "bugfix",
-        "scope": "commands",
-        "summary": "add conftest.py to scaffold + split tests + missing tests from PR",
-        "breaking": false,
-        "requires_reinstall": true,
-        "files": [
-          "commands/forge-phases/phase-a-setup.md",
-          "tests/bash/unit/phase-a-fixes.bats"
-        ],
-        "issues": [
-          "#144",
-          "#153",
-          "#154",
-          "#167"
-        ]
-      },
-      {
-        "date": "2026-04-06",
-        "commit": "9bca6a72",
-        "change_type": "bugfix",
-        "scope": "commands",
-        "summary": "address remaining CR comments \u2014 scaffold test, registry regenerate",
-        "breaking": false,
-        "requires_reinstall": false,
-        "files": [
-          "forge-registry.json"
-        ],
-        "issues": [
-          "#154"
-        ]
-      },
-      {
-        "date": "2026-04-06",
-        "commit": "cf85b472",
-        "change_type": "bugfix",
-        "scope": "commands",
-        "summary": "address CR changes \u2014 recovery path, multi-stack downstream, full script path",
-        "breaking": false,
-        "requires_reinstall": true,
-        "files": [
-          "commands/forge-phases/phase-a-setup.md"
-        ],
-        "issues": [
-          "#154",
-          "#167"
-        ]
-      },
-      {
-        "date": "2026-04-06",
-        "commit": "8993babe",
-        "change_type": "bugfix",
-        "scope": "commands",
-        "summary": "simplify Phase A S1 \u2014 remove duplicate detection, keep only prepare",
-        "breaking": false,
-        "requires_reinstall": true,
-        "files": [
-          "README.md",
-          "commands/forge-phases/phase-a-setup.md",
-          "docs/dependency-graph.md",
-          "forge-registry.json",
-          "tests/bash/unit/phase-a-fixes.bats"
-        ],
-        "issues": [
-          "#169"
-        ]
-      },
-      {
-        "date": "2026-04-06",
-        "commit": "b3be62b4",
-        "change_type": "bugfix",
-        "scope": "commands",
-        "summary": "brownfield \u2014 multi-framework detection + missing infra check #149",
-        "breaking": false,
-        "requires_reinstall": true,
-        "files": [
-          "commands/forge-phases/phase-a-setup.md",
-          "forge-registry.json"
-        ],
-        "issues": [
-          "#149",
-          "#152"
-        ]
-      },
-      {
-        "date": "2026-04-06",
-        "commit": "ecdde2e4",
-        "change_type": "bugfix",
-        "scope": "commands",
-        "summary": "Phase A Batch 4 \u2014 state persistence + partial setup + S9 fix path #132 #156",
-        "breaking": false,
-        "requires_reinstall": true,
-        "files": [
-          "README.md",
-          "commands/forge-phases/phase-a-setup.md",
-          "docs/dependency-graph.md",
-          "forge-registry.json",
-          "tests/bash/unit/phase-a-fixes.bats"
-        ],
-        "issues": [
-          "#132",
-          "#156",
-          "#159"
-        ]
-      },
-      {
-        "date": "2026-04-06",
-        "commit": "bf71e57a",
-        "change_type": "bugfix",
-        "scope": "commands",
-        "summary": "Phase A Batch 3 \u2014 S6-S8 infrastructure fixes #136 #137 #145 #157",
-        "breaking": false,
-        "requires_reinstall": true,
-        "files": [
-          "README.md",
-          "commands/forge-phases/phase-a-setup.md",
-          "docs/dependency-graph.md",
-          "forge-registry.json",
-          "tests/bash/unit/phase-a-fixes.bats"
-        ],
-        "issues": [
-          "#136",
-          "#137",
-          "#145",
-          "#157",
-          "#158"
-        ]
-      },
-      {
-        "date": "2026-04-06",
-        "commit": "aa742c1a",
-        "change_type": "bugfix",
-        "scope": "commands",
-        "summary": "Phase A Batch 2 \u2014 S3-S5 generation fixes #131 #133 #139 #140",
-        "breaking": false,
-        "requires_reinstall": true,
-        "files": [
-          "README.md",
-          "commands/forge-phases/phase-a-setup.md",
-          "docs/dependency-graph.md",
-          "forge-registry.json",
-          "tests/bash/unit/phase-a-fixes.bats"
-        ],
-        "issues": [
-          "#131",
-          "#133",
-          "#139",
-          "#140",
-          "#143"
-        ]
-      },
-      {
-        "date": "2026-04-06",
-        "commit": "0a69d0ef",
-        "change_type": "bugfix",
-        "scope": "commands",
-        "summary": "Phase A Batch 1 \u2014 S2 question fixes #135 #138 #146",
-        "breaking": false,
-        "requires_reinstall": true,
-        "files": [
-          "README.md",
-          "commands/forge-phases/phase-a-setup.md",
-          "docs/dependency-graph.md",
-          "forge-registry.json",
-          "tests/bash/unit/phase-a-fixes.bats"
-        ],
-        "issues": [
-          "#135",
-          "#138",
-          "#146",
-          "#147"
-        ]
-      },
-      {
-        "date": "2026-04-06",
-        "commit": "2c6f13c7",
-        "change_type": "bugfix",
-        "scope": "commands",
-        "summary": "Phase A S1 \u2014 add git init guard if .git missing",
-        "breaking": false,
-        "requires_reinstall": true,
-        "files": [
-          "README.md",
-          "commands/forge-phases/phase-a-setup.md",
-          "forge-registry.json",
-          "tests/bash/unit/phase-a-fixes.bats"
-        ],
-        "issues": [
-          "#129",
-          "#130",
-          "#134",
-          "#155"
-        ]
-      },
-      {
-        "date": "2026-04-06",
-        "commit": "9fc956a4",
-        "change_type": "test",
-        "scope": "commands",
-        "summary": "add 6 validation tests for 45 commands",
-        "breaking": false,
-        "requires_reinstall": false,
-        "files": [
-          "tests/bash/unit/all-commands-validation.bats"
-        ],
-        "issues": [
-          "#83"
-        ]
-      },
-      {
-        "date": "2026-04-05",
-        "commit": "90a0c99f",
-        "change_type": "feature",
-        "scope": "commands",
-        "summary": "add 9 sc:* commands from SuperClaude \u2014 unblocks Phase 2, 4, 5",
-        "breaking": false,
-        "requires_reinstall": true,
-        "files": [
-          "commands/sc-analyze.md",
-          "commands/sc-cleanup.md",
-          "commands/sc-document.md",
-          "commands/sc-estimate.md",
-          "commands/sc-improve.md",
-          "commands/sc-reflect.md",
-          "commands/sc-save.md",
-          "commands/sc-test.md",
-          "commands/sc-workflow.md",
-          "tests/bash/unit/sc-commands.bats"
-        ],
-        "issues": [
-          "#61"
-        ]
-      },
-      {
-        "date": "2026-04-05",
-        "commit": "ac88ee95",
-        "change_type": "feature",
-        "scope": "commands",
-        "summary": "create /autoresearch command \u2014 unblocks Phase 5 step 54",
-        "breaking": false,
-        "requires_reinstall": true,
-        "files": [
-          "commands/autoresearch.md",
-          "tests/bash/unit/autoresearch-command.bats"
-        ],
-        "issues": [
-          "#60"
         ]
       }
     ],

--- a/rules/pm-behaviors.md
+++ b/rules/pm-behaviors.md
@@ -1,0 +1,92 @@
+# PM Behaviors — Universal Rules for the Forge Orchestrator
+
+Auto-loaded via Pipe 1. These rules apply whenever Claude acts as PM (during /forge or any orchestration task). The PM orchestrates — it NEVER writes application code.
+
+## Self-Correction Loop
+
+<system-reminder>
+NEVER retry without investigating. NEVER dismiss warnings. NEVER skip quality gates.
+
+Error occurs → STOP → "Why did this happen?" → investigate → root cause
+→ Design DIFFERENT approach → Execute → Measure → learn
+
+- Max 3 self-fix attempts per issue
+- After 2 failed corrections → STOP, document what was tried, ask user
+- Use /investigate for root cause before any fix
+- NEVER retry the same approach — try something DIFFERENT
+</system-reminder>
+
+## Confidence Routing
+
+- If confidence in output < 80% → state: "CONFIDENCE: LOW — [reason]. Recommend human review before proceeding."
+- If confidence ≥ 80% → state: "CONFIDENCE: HIGH — proceeding autonomously."
+- Low confidence triggers: unfamiliar stack, conflicting docs, ambiguous requirements, no context7 docs available.
+
+## Anti-Patterns (NEVER do these)
+
+<system-reminder>
+1. NEVER write application code — ONLY delegate to specialist agents
+2. NEVER skip the research step — every agent MUST research before implementing
+3. NEVER proceed past a failed /gate — fix ALL issues first
+4. NEVER spawn agents without providing focused context (task + [REQ-xxx] + rules)
+5. NEVER dismiss warnings from any agent — investigate every one
+6. NEVER skip /learn after discovering a non-obvious pattern
+7. NEVER let agents write code without @context-loader-agent fetching docs first
+</system-reminder>
+
+## Quality Minimums (BLOCK if not met)
+
+- Tests: minimum 5 per issue, 10+ per domain/app
+- REQ coverage: 100% (every REQ has test + code)
+- Design doc: ALL 10 sections complete
+- Security: @security-engineer audit before Phase 4 gate
+- Review: @reviewer rates >= 4 on every agent output
+
+## Handoff Protocol
+
+Always return results in this format:
+```text
+## [Task] Completed
+### Summary: [2-3 sentences]
+### Requirements Covered: [REQ-xxx] list
+### Quality: Tests [pass/fail], Lint [clean/issues]
+### Delegation Hints: [next agent to call]
+### Risks/Blockers: [any issues]
+### Files Created/Modified: [list]
+```
+
+## Tool Failure Handling
+
+- context7 unavailable → fall back to web search → fall back to training knowledge (state: "context7 unavailable, used [fallback]")
+- Bash command fails → read error → classify (syntax vs permission vs missing tool) → fix or report
+- Web search returns nothing → try different terms (max 3) → report "no external data, using training knowledge"
+- NEVER silently skip a failed tool — always report what failed and what fallback was used
+
+## Chaos Resilience
+
+- No SPEC.md or CLAUDE.md → STOP: "Cannot orchestrate without project definition."
+- Agent returns empty output → retry once with clearer prompt, then escalate to user
+- Multiple agents fail in sequence → STOP after 2 consecutive failures, report pattern
+- GitHub API unavailable → continue without issue tracking, document tasks locally
+- User gives contradictory instructions → ask for clarification, do NOT guess intent
+
+## Timeline Tracking (MANDATORY)
+
+After EVERY action, append to docs/forge-timeline.md:
+```text
+## [TIMESTAMP] [STEP-NAME]
+**Flow:** [NEW_PROJECT | BUG_FIX | NEW_FEATURE | IMPROVEMENT]
+**Agent:** [@agent-name or /command-name]
+**Input:** [what was given]
+**Output:** [file] -> [link]
+**Status:** [DONE | BLOCKED | NEEDS_REVIEW | IN_PROGRESS]
+**REQs:** [REQ-xxx addressed]
+```
+
+## Execution Trace (MANDATORY)
+
+After EVERY agent execution, save to docs/forge-trace/:
+1. Create numbered folder: docs/forge-trace/{NNN}-{step-name}/
+2. Save input.md — what was given to the agent
+3. Save output.md — what came back
+4. Save meta.md — agent, timestamp, duration, status

--- a/tests/bash/unit/pm-behaviors-rules.bats
+++ b/tests/bash/unit/pm-behaviors-rules.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+# Tests for PM behaviors rules architecture (#173)
+# Verifies the "who vs what" separation
+
+setup() {
+    load '../../test_helper/common-setup'
+    _common_setup
+    FORGE_DIR="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+    export FORGE_DIR
+}
+
+teardown() {
+    _common_teardown
+}
+
+# ─── rules/pm-behaviors.md exists and has key sections ───
+
+@test "pm-behaviors.md rules file exists" {
+    assert [ -f "$FORGE_DIR/rules/pm-behaviors.md" ]
+}
+
+@test "pm-behaviors has self-correction rules" {
+    run grep -iE "self.correct|max 3|retry|investigate.*before" "$FORGE_DIR/rules/pm-behaviors.md"
+    assert_success
+}
+
+@test "pm-behaviors has confidence routing" {
+    run grep -iE "confidence|80%|LOW.*human|HIGH.*autonomous" "$FORGE_DIR/rules/pm-behaviors.md"
+    assert_success
+}
+
+@test "pm-behaviors has anti-patterns" {
+    run grep -iE "NEVER write.*code|NEVER skip|NEVER bypass" "$FORGE_DIR/rules/pm-behaviors.md"
+    assert_success
+}
+
+@test "pm-behaviors has handoff protocol" {
+    run grep -iE "handoff|Summary.*REQ|Quality.*Tests|Delegation" "$FORGE_DIR/rules/pm-behaviors.md"
+    assert_success
+}
+
+@test "pm-behaviors has chaos resilience" {
+    run grep -iE "chaos|no SPEC.*stop|empty output.*retry|contradictory" "$FORGE_DIR/rules/pm-behaviors.md"
+    assert_success
+}
+
+@test "pm-behaviors has tool failure handling" {
+    run grep -iE "context7.*unavailable|fallback|web search.*training" "$FORGE_DIR/rules/pm-behaviors.md"
+    assert_success
+}
+
+@test "pm-behaviors is under 200 lines" {
+    local lines
+    lines=$(wc -l < "$FORGE_DIR/rules/pm-behaviors.md")
+    [ "$lines" -le 200 ]
+}
+
+# ─── phase-a-setup.md references rules, not duplicates ───
+
+@test "phase-a-setup references pm-behaviors auto-load" {
+    run grep -iE "pm-behaviors|auto-load|rules.*pm" "$FORGE_DIR/commands/forge-phases/phase-a-setup.md"
+    assert_success
+}
+
+@test "phase-a-setup does NOT have duplicated anti-patterns" {
+    # The detailed anti-pattern list should be in rules, not phase file
+    run grep -c "NEVER write application code" "$FORGE_DIR/commands/forge-phases/phase-a-setup.md"
+    # Should be 0 or 1 (brief reference OK, detailed list should be in rules)
+    [[ "$output" -le 1 ]]
+}
+
+# ─── pm-orchestrator.md references rules file ───
+
+@test "pm-orchestrator references pm-behaviors rules" {
+    run grep -iE "pm-behaviors|rules.*pm|auto-load.*behaviors" "$FORGE_DIR/agents/universal/pm-orchestrator.md"
+    assert_success
+}

--- a/tests/bash/unit/rules-validation.bats
+++ b/tests/bash/unit/rules-validation.bats
@@ -13,7 +13,7 @@ teardown() {
 @test "rule count is 7" {
     local count
     count=$(ls "$FORGE_DIR"/rules/*.md 2>/dev/null | wc -l)
-    [ "$count" -eq 7 ]
+    [ "$count" -eq 8 ]
 }
 
 @test "all rules are valid markdown" {


### PR DESCRIPTION
## Summary

Architecture change per CR plan from issue #173.

### New: rules/pm-behaviors.md (~100 lines)
Auto-loaded via Pipe 1. Contains:
- Self-correction loop
- Confidence routing
- Anti-patterns (7 NEVER rules)
- Handoff protocol
- Tool failure handling
- Chaos resilience
- Timeline + trace requirements

### Architecture Separation
```
rules/pm-behaviors.md     → WHO: PM behaviors (auto-loaded, ~100 lines)
pm-orchestrator.md        → REFERENCE: routing tables, detailed patterns
phase-a-setup.md          → WHAT: task steps for Phase A
```

### Files Changed
- NEW: rules/pm-behaviors.md
- UPDATED: agents/universal/pm-orchestrator.md (references rules)
- UPDATED: commands/forge-phases/phase-a-setup.md (references auto-load)
- UPDATED: docs/architecture.md (documents separation)
- UPDATED: README.md (rules 7→8)

TDD: 11 tests. 368 total, 0 failures.

Closes #173

- [ ] CodeRabbit explicit APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to clarify system component organization and how PM behaviors are auto-loaded.

* **New Features**
  * Added PM behaviors ruleset defining self-correction limits, confidence routing, anti-patterns, quality gates, and handoff protocols.

* **Tests**
  * Expanded test suite from 351 to 368 tests.
  * Added validation tests for PM behaviors rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->