### PR TITLE
fix: add YAML frontmatter to forge.md per Claude Code standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ What gets installed (to `~/.claude/`, shared by all projects):
 | Rules | 8 | ~/.claude/rules/ | Global rules (security, python, docker, PM behaviors, etc.) |
 | Scripts | 30 | ~/.claude/scripts/ | Enforcement, traceability, ownership, testing |
 | Templates | 22 | ~/.claude/templates/ | Project scaffolding (CLAUDE.md, SPEC.md, hooks, etc.) |
-| Tests | 368 | tests/ | BATS + pytest test suite (100% script coverage) |
+| Tests | 372 | tests/ | BATS + pytest test suite (100% script coverage) |
 | Shell fn | 1 | ~/.bashrc / ~/.zshrc | `forge` terminal command |
 
 ---

--- a/commands/forge.md
+++ b/commands/forge.md
@@ -1,4 +1,8 @@
-# /forge -- One Command to Build Everything
+---
+description: "Main SDLC orchestrator. Detects project state automatically and routes to the right flow: new project setup, feature addition, bug fix, improvement, or resume."
+argument-hint: "[description of what to build | empty to auto-detect]"
+---
+# /forge — One Command to Build Everything
 
 ## Input
 $ARGUMENTS -- optional. Can be:

--- a/forge-registry.json
+++ b/forge-registry.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "generated": "2026-04-06T20:58:52.219626+00:00",
+  "generated": "2026-04-06T21:19:49.091016+00:00",
   "forge_dir": "/home/intruder/projects/forge",
   "stats": {
     "agents": 51,
@@ -6687,6 +6687,46 @@
     }
   },
   "changelog": {
+    "rules": [
+      {
+        "date": "2026-04-06",
+        "commit": "c5c612a4",
+        "change_type": "feature",
+        "scope": "rules",
+        "summary": "extract PM behaviors into auto-loaded rules file \u2014 who vs what separation",
+        "breaking": false,
+        "requires_reinstall": true,
+        "files": [
+          "README.md",
+          "agents/universal/pm-orchestrator.md",
+          "commands/forge-phases/phase-a-setup.md",
+          "docs/architecture.md",
+          "docs/dependency-graph.md",
+          "forge-registry.json",
+          "rules/pm-behaviors.md",
+          "tests/bash/unit/pm-behaviors-rules.bats",
+          "tests/bash/unit/rules-validation.bats"
+        ],
+        "issues": [
+          "#173"
+        ]
+      },
+      {
+        "date": "2026-04-06",
+        "commit": "aa520697",
+        "change_type": "test",
+        "scope": "rules",
+        "summary": "add 7 auto-load validation tests for 7 rules",
+        "breaking": false,
+        "requires_reinstall": false,
+        "files": [
+          "tests/bash/unit/rules-validation.bats"
+        ],
+        "issues": [
+          "#85"
+        ]
+      }
+    ],
     "commands": [
       {
         "date": "2026-04-06",
@@ -7779,23 +7819,6 @@
         ],
         "issues": [
           "#92"
-        ]
-      }
-    ],
-    "rules": [
-      {
-        "date": "2026-04-06",
-        "commit": "aa520697",
-        "change_type": "test",
-        "scope": "rules",
-        "summary": "add 7 auto-load validation tests for 7 rules",
-        "breaking": false,
-        "requires_reinstall": false,
-        "files": [
-          "tests/bash/unit/rules-validation.bats"
-        ],
-        "issues": [
-          "#85"
         ]
       }
     ],

--- a/tests/bash/unit/forge-md-frontmatter.bats
+++ b/tests/bash/unit/forge-md-frontmatter.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+# Tests for forge.md frontmatter (#175)
+
+setup() {
+    load '../../test_helper/common-setup'
+    _common_setup
+    FORGE_DIR="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+    export FORGE_DIR
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "forge.md has YAML frontmatter" {
+    run head -1 "$FORGE_DIR/commands/forge.md"
+    assert_output "---"
+}
+
+@test "forge.md has description field" {
+    run grep "^description:" "$FORGE_DIR/commands/forge.md"
+    assert_success
+}
+
+@test "forge.md has argument-hint field" {
+    run grep "^argument-hint:" "$FORGE_DIR/commands/forge.md"
+    assert_success
+}
+
+@test "forge.md does NOT use context: fork" {
+    run grep "context: fork" "$FORGE_DIR/commands/forge.md"
+    assert_failure
+}


### PR DESCRIPTION
Added description + argument-hint frontmatter per CR plan from #175.
NOT using context:fork (needs user interaction).

TDD: 4 tests. 350 total, 0 failures.

Closes #175

- [ ] CodeRabbit explicit APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced `/forge` command documentation with structured metadata including description and usage hints.

* **Tests**
  * Expanded test suite to 372 tests with new validation coverage for command documentation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->